### PR TITLE
Fixed a layout issue

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -12,6 +12,7 @@
 
   .container {
     margin-top: 100px;
+    margin-bottom: 100px;
   }
 
   .boolio-img-logo{


### PR DESCRIPTION
The app store button would be covered up on a short screen because there was no margin at the bottom of the container so the footer covered it. This is fixed here
